### PR TITLE
fix for log in Deep Standby

### DIFF
--- a/openwebif/api.py
+++ b/openwebif/api.py
@@ -631,10 +631,12 @@ class CreateDevice:
         try:
             response = self.session.get(url)
         except requests.exceptions.ConnectionError as err:
-            _LOGGER.error(f"There was a connection error calling {url}"
+            if not self.is_offline:
+                _LOGGER.error(f"There was a connection error calling {url}"
                           f" Please check the network connection to the Enigma2"
                           f" box is ok and enable debug logging in "
                           f"Enigma2 if required. Error: {err}")
+                self.is_offline = True
             return None
 
         _LOGGER.debug(f"Got {response.status_code} from : %s", url)
@@ -644,11 +646,11 @@ class CreateDevice:
             _LOGGER.error(error_msg)
 
             # If box is in deep standby, dont raise this
-            # over and over.
-            if not self.is_offline:
-                message = f"{url} is unreachable."
-                _LOGGER.warning(message)
-                self.is_offline = True
+            # over and over. (Too late here)
+            #if not self.is_offline:
+            #    message = f"{url} is unreachable."
+            #    _LOGGER.warning(message)
+            #    self.is_offline = True
             return None
 
         self.is_offline = False


### PR DESCRIPTION
This module is used inside homeassistant. If a previously discovered devive is entering DeepStandby and you don't want to wakeup the device again, the device is discovered frequently (by calling statusinfo) and this blows up the logs:

`ERROR (SyncWorker_0) [openwebif.api] There was a connection error calling http://xxxx:80/api/statusinfo Please check the network connection to the Enigma2 box is ok and enable debug logging in Enigma2 if required. Error: HTTPConnectionPool(host='xxxx', port=80): Max retries exceeded with url: /api/statusinfo (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x64b94b38>: Failed to establish a new connection: [Errno 111] Connection refused'))`

You can configure logging for this module but than you'll loose other important logs as well.
There is an error reported in HA (https://github.com/home-assistant/core/issues/46796) but closed thru inactivity and since this module is independent I opened it here and did a quickfix for that.
I think the problem lies in _call_api (api.py) L632 url is called hich is causing the log. Later (which is not called due to the error) in L648 the offline state is checked and set, but it is too late.
